### PR TITLE
Add CORS configuration for local development

### DIFF
--- a/backend/src/main/java/com/constructpro/config/SecurityConfig.java
+++ b/backend/src/main/java/com/constructpro/config/SecurityConfig.java
@@ -78,7 +78,8 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http.csrf(csrf -> csrf.disable())
+		http.cors(cors -> {})
+			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> auth
 												   .requestMatchers("/api/auth/**").permitAll() // login, signup open
 												   .anyRequest().authenticated()

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,22 @@ export function createServer() {
   const app = express();
 
   // Middleware
-  app.use(cors());
+  const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? "http://localhost:3000,http://localhost:5173,http://localhost:8080,http://localhost:8081").split(",");
+
+  const corsOptions: cors.CorsOptions = {
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true); // allow non-browser or same-origin requests
+      if (allowedOrigins.includes(origin)) return callback(null, true);
+      return callback(new Error("Not allowed by CORS"));
+    },
+    credentials: true,
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+    exposedHeaders: ["Content-Length"],
+  };
+
+  app.use(cors(corsOptions));
+  app.options("*", cors(corsOptions));
   app.use(express.json({ limit: "60mb" })); // Increased for base64 encoded files
   app.use(express.urlencoded({ extended: true, limit: "60mb" }));
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,10 @@ export function createServer() {
   const app = express();
 
   // Middleware
-  const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? "http://localhost:3000,http://localhost:5173,http://localhost:8080,http://localhost:8081").split(",");
+  const allowedOrigins = (
+    process.env.CORS_ALLOWED_ORIGINS ??
+    "http://localhost:3000,http://localhost:5173,http://localhost:8080,http://localhost:8081"
+  ).split(",");
 
   const corsOptions: cors.CorsOptions = {
     origin: (origin, callback) => {


### PR DESCRIPTION
## Purpose
The user needed to enable CORS configuration to test the application locally with separate frontend and backend servers. They were encountering a 502 Bad Gateway error when making requests from the frontend to the backend API at `http://localhost:8080/api/auth/login`.

## Code changes
- **Java SecurityConfig**: Added `.cors(cors -> {})` to enable CORS support in Spring Security configuration
- **Node.js server**: Replaced basic `cors()` middleware with detailed CORS configuration including:
  - Configurable allowed origins via environment variable (defaults to common local development ports)
  - Enabled credentials support
  - Specified allowed HTTP methods and headers
  - Added preflight OPTIONS request handling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6068060486fe4416854fad541b293928/neon-studio)

👀 [Preview Link](https://6068060486fe4416854fad541b293928-neon-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6068060486fe4416854fad541b293928</projectId>-->
<!--<branchName>neon-studio</branchName>-->